### PR TITLE
Improve prompt

### DIFF
--- a/action/src/chat.d.ts
+++ b/action/src/chat.d.ts
@@ -2,5 +2,5 @@ export declare class Chat {
     private chatAPI;
     constructor(apikey: string);
     private generatePrompt;
-    codeReview: (patch: string) => Promise<string>;
+    codeReview: (filePath: string, patch: string) => Promise<string>;
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -139,7 +139,7 @@ export const robot = (app: Probot) => {
         }
 
         try {
-          const res = await chat?.codeReview(patch);
+          const res = await chat?.codeReview(file.filename, patch);
 
           if (!!res) {
             await context.octokit.pulls.createReviewComment({

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -63,16 +63,18 @@ export const robot = (app: Probot) => {
         return 'invalid event payload';
       }
 
-      const noReviewLabels = [
-        'no-review-by-ChatGPT',
-        'renovate/Major',
-        'renovate/Minor',
-        'renovate/Patch',
-        'renovate/security'
-      ]
-      if (pull_request.labels?.some(label => noReviewLabels.includes(label.name))) {
-        console.log('no-review label is attached.');
-        return 'no-review label is attached.'
+      if (process.env.TRIGGER !== 'command') {
+        const noReviewLabels = [
+          'no-review-by-ChatGPT',
+          'renovate/Major',
+          'renovate/Minor',
+          'renovate/Patch',
+          'renovate/security'
+        ]
+        if (pull_request.labels?.some(label => noReviewLabels.includes(label.name))) {
+          console.log('no-review label is attached.');
+          return 'no-review label is attached.'
+        }
       }
 
       const targets = (process.env.TARGETS || process.env.targets || '')

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -20,7 +20,7 @@ export class Chat {
 
   private generatePrompt = (fileExtension: string, patch: string) => {
     const answerLanguage = process.env.LANGUAGE ? process.env.LANGUAGE : 'Japanese';
-    if (process.env.PROMPT !== ''){
+    if (!!process.env.PROMPT){
       return `${process.env.PROMPT}, Answer me in ${answerLanguage}:
       ${patch}
       `;

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -68,7 +68,7 @@ Review Format
 
     console.time('code-review cost');
     const prompt = this.generatePrompt(fileExtension, patch);
-    console.log(prompt)
+    console.info(prompt)
 
     const res = await this.chatAPI.sendMessage(prompt);
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -39,7 +39,6 @@ ${patch}
 
 Review Format
 
-\`\`\`
 ## Review Summary
 
 ## Bug Risks
@@ -52,8 +51,7 @@ Review Format
 
 ### 1. ~ (1st suggestion, please fill the title)
 
-(Please continue to comment as needed.)
-\`\`\``;
+(Please continue to comment as needed.)`;
     }
   };
 
@@ -68,7 +66,6 @@ Review Format
 
     console.time('code-review cost');
     const prompt = this.generatePrompt(fileExtension, patch);
-    console.info(prompt)
 
     const res = await this.chatAPI.sendMessage(prompt);
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -68,6 +68,7 @@ Review Format
 
     console.time('code-review cost');
     const prompt = this.generatePrompt(fileExtension, patch);
+    console.log(prompt)
 
     const res = await this.chatAPI.sendMessage(prompt);
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -18,27 +18,56 @@ export class Chat {
     });
   }
 
-  private generatePrompt = (patch: string) => {
-    const answerLanguage = process.env.LANGUAGE
-      ? `Answer me in ${process.env.LANGUAGE},`
-      : 'Answer me in Japanese,';
+  private generatePrompt = (fileExtension: string, patch: string) => {
+    const answerLanguage = process.env.LANGUAGE ? process.env.LANGUAGE : 'Japanese';
+    if (process.env.PROMPT !== ''){
+      return `${process.env.PROMPT}, Answer me in ${answerLanguage}:
+      ${patch}
+      `;
+    } else {
+      const fileTypeMessage = fileExtension !== '' ? ` for a ${fileExtension} file` : '';
 
-    const prompt =
-      process.env.PROMPT ||
-        'Below is a code patch, please help me do a brief code review on it. Any bug risks and/or improvement suggestions are welcome:';
+      return `You are a skilled software engineer.
+Below is a code patch${fileTypeMessage}. Please help me review it.
+The review comments must be in the following format in ${answerLanguage}.
 
-    return `${prompt}, ${answerLanguage}:
-    ${patch}
-    `;
+Patch
+
+\`\`\`
+${patch}
+\`\`\`
+
+Review Format
+
+\`\`\`
+## Review Summary
+
+## Bug Risks
+
+### 1. ~ (1st risk, please fill the title)
+
+(Please continue to comment as needed.)
+
+## Improvement Suggestions
+
+### 1. ~ (1st suggestion, please fill the title)
+
+(Please continue to comment as needed.)
+\`\`\``;
+    }
   };
 
-  public codeReview = async (patch: string) => {
+  public codeReview = async (filePath: string, patch: string) => {
     if (!patch) {
       return '';
     }
 
+    const fileName = filePath.split('/').at(-1) as string;
+    const splitFileName = fileName.split('.');
+    const fileExtension = splitFileName.length > 1 ? splitFileName.at(-1) as string : '';
+
     console.time('code-review cost');
-    const prompt = this.generatePrompt(patch);
+    const prompt = this.generatePrompt(fileExtension, patch);
 
     const res = await this.chatAPI.sendMessage(prompt);
 


### PR DESCRIPTION
# Related Issues

<!-- 不具合対応時のみ記載
## 問題

## 原因

-->

# 対処・修正内容

- デフォルトのプロンプト改善
  - `You are a skilled software engineer.`追加
  - `a code patch for a go file`のようにファイルの拡張子をプロンプトに含める（下記`${fileTypeMessage}`部分）
    - 拡張子がなかったら省略
  - レビューコメントのフォーマット指定
    ```
    You are a skilled software engineer.
    Below is a code patch${fileTypeMessage}. Please help me review it.
    The review comments must be in the following format in ${answerLanguage}.

    Patch

    ${patch}

    Review Format

    ## Review Summary

    ## Bug Risks

    ### 1. ~ (1st risk, please fill the title)

    (Please continue to comment as needed.)

    ## Improvement Suggestions

    ### 1. ~ (1st suggestion, please fill the title)

    (Please continue to comment as needed.)
    ```
- 環境変数`TRIGGER`が`command`のときはPRのラベルを見ないようにした
  - PRに`/review`とコメントしてレビューを走らせたとき用

# 影響範囲

# 動作確認環境のURL

# 完了条件・試験項目
<!-- チェックをつける-->
- [ ] xxxxx
- [ ] xxxxx

# エビデンス
<!-- image貼る or code載せる 出力結果をコピペする etc... -->

# その他
